### PR TITLE
set prep-phase errorStrategy to terminate after retries

### DIFF
--- a/conf/rockfish.config
+++ b/conf/rockfish.config
@@ -35,7 +35,7 @@ process {
 
     // first three processes were prev all one processes `prepare_simulation_files`
     withLabel: bcftools_rename_chroms {
-        errorStrategy = 'retry'
+        errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'terminate' }
         maxRetries = 3
     }
     withLabel: bcftools_extract_strains {
@@ -43,14 +43,14 @@ process {
         cpus = 4
         memory = "40G"
         array = 100
-        errorStrategy = 'retry'
+        errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'terminate' }
         maxRetries = 3
     }
     withLabel: bcftools_create_genotype_matrix {
         time = "1.hour"
         cpus = 4
         memory = "40G"
-        errorStrategy = 'retry'
+        errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'terminate' }
         maxRetries = 3
         array = 100
     }
@@ -58,7 +58,7 @@ process {
         time = "1.hour"
         cpus = 4
         memory = "40G"
-        errorStrategy = 'retry'
+        errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'terminate' }
         maxRetries = 3
         array = 100
     }
@@ -68,7 +68,7 @@ process {
         time = "30.minute"
         cpus = 2
         memory = "60G"
-        errorStrategy = 'retry'
+        errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'terminate' }
         maxRetries = 3
         array = 100
     }


### PR DESCRIPTION
Update the marker set prep-phase processes to terminate cleanly on retry exhaustion instead of falling through to the global 'retry' default.