### PR TITLE
drop failed reps via errorStrategy ignore on post-fanout processes

### DIFF
--- a/conf/rockfish.config
+++ b/conf/rockfish.config
@@ -78,7 +78,7 @@ process {
         time = "10.minute"
         cpus = 1          // --simu-qt pinned to thread-num 1 for numerical determinism
         memory = "20G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -86,23 +86,23 @@ process {
         time = "10.minute"
         cpus = 4
         memory = "20G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
     withLabel: gcta_make_grm {
-        time = "10.minute"
+        time   = { 10.minute * task.attempt }
+        memory = { 20.GB * Math.pow(1.5, task.attempt - 1) }
         cpus = 1  // all GCTA ops pinned to thread-num 1 for numerical determinism
-        memory = "20G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
     withLabel: gcta_perform_gwa {
-        time = "10.minute"
+        time   = { 10.minute * task.attempt }
+        memory = { 20.GB * Math.pow(1.5, task.attempt - 1) }
         cpus = 4
-        memory = "20G"
-        errorStrategy = { task.attempt <= task.maxRetries ? 'retry' : 'ignore' }
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -112,7 +112,7 @@ process {
         time = "10.minute"
         cpus = 1
         memory = "2G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -120,7 +120,7 @@ process {
         time = "10.minute"
         cpus = 1
         memory = "2G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -128,9 +128,10 @@ process {
     // previous process `get_gcta_intervals`
     withLabel: r_get_gcta_intervals {
         clusterOptions = '-A eande106_bigmem -e errlog.txt -N 1 -p bigmem'
-        time = { "4.hour" * task.attempt }
+        time   = { 4.hour * task.attempt }
+        memory = { 20.GB * Math.pow(1.5, task.attempt - 1) }
         cpus = 1
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 5
         array = 100
     }
@@ -140,7 +141,7 @@ process {
         time = "20.minute"
         cpus = 1
         memory = "20G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -149,15 +150,15 @@ process {
         time = "30.minute"
         cpus = 2
         memory = "8G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
     withLabel: db_migration_write_gwa_to_db {
-        time = "10.minute"
+        time   = { 10.minute * task.attempt }
+        memory = { 4.GB * Math.pow(1.5, task.attempt - 1) }
         cpus = 1
-        memory = "4G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -165,14 +166,14 @@ process {
         time = "10.minute"
         cpus = 1
         memory = "4G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 2
     }
     withLabel: db_migration_analyze_qtl {
         time = "20.minute"
         cpus = 1
         memory = "8G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -180,7 +181,7 @@ process {
         time = "20.minute"
         cpus = 1
         memory = "8G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }
@@ -188,14 +189,14 @@ process {
         time = "10.minute"
         cpus = 1
         memory = "8G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
     }
     withLabel: db_migration_write_trait_data {
         time = "5.minute"
         cpus = 1
         memory = "2G"
-        errorStrategy = 'retry'
+        errorStrategy = { workflow.stubRun ? 'retry' : (task.attempt <= task.maxRetries ? 'retry' : 'ignore') }
         maxRetries = 3
         array = 100
     }


### PR DESCRIPTION
Convert post-fanout processes from “halt the pipeline on retry exhaustion” to “drop the failed slot and continue” via errorStrategy = 'ignore'