### PR TITLE
outdir

### DIFF
--- a/conf/rockfish.config
+++ b/conf/rockfish.config
@@ -3,7 +3,7 @@
 */
 
 if (params.output_dir == null) {
-    log.error "rockfish profile requires --output_dir so the failures directory is on a persistent path"
+    System.err.println "ERROR: rockfish profile requires --output_dir so the failures directory is on a persistent path"
     System.exit(1)
 }
 


### PR DESCRIPTION
Replace log.error with System.err.println, which is available in the config context